### PR TITLE
Fix the term sync when having a parent

### DIFF
--- a/classes/client/taxonomy.php
+++ b/classes/client/taxonomy.php
@@ -30,13 +30,14 @@ class BEA_CSF_Client_Taxonomy {
 				'name'        => $data['name'],
 				'description' => $data['description'],
 				'slug'        => $data['slug'],
-				'parent'      => $data['parent'],
+				'parent'      => BEA_CSF_Relations::get_object_for_any( 'taxonomy', $data['blogid'], $sync_fields['_current_receiver_blog_id'], $data['parent'], $data['parent'] ),
 			) );
 		} else {
 			$new_term_id = wp_insert_term( $data['name'], $data['taxonomy'], array(
 				'description' => $data['description'],
 				'slug'        => $data['slug'],
-				'parent'      => $data['parent'],
+				'parent'      => BEA_CSF_Relations::get_object_for_any( 'taxonomy', $data['blogid'], $sync_fields['_current_receiver_blog_id'], $data['parent'], $data['parent'] ),
+
 			) );
 
 			// try to manage error when term already exist with the same name !


### PR DESCRIPTION
The parent_id is used from the $data array but is not transformed to the local version.
So if the all the ids stay the same from emitter to the receiver eveyrthing is fine, but if there is already existing content the link is missing.