### PR TITLE
Slash post data before wp_insert_post/wp_update_post

### DIFF
--- a/classes/client/attachment.php
+++ b/classes/client/attachment.php
@@ -63,6 +63,9 @@ class BEA_CSF_Client_Attachment {
 		$data_for_post = $data;
 		unset( $data_for_post['taxonomies'], $data_for_post['terms'], $data_for_post['post_custom'], $data_for_post['metadata'] );
 
+		// Post data are expected to be escaped for wp_insert_post/wp_update_post
+		$data_for_post = wp_slash( $data_for_post );
+
 		// Merge or add ?
 		if ( ! empty( $current_media_id ) && (int) $current_media_id > 0 ) { // Edit, update only main fields
 

--- a/classes/client/post_type.php
+++ b/classes/client/post_type.php
@@ -37,6 +37,9 @@ class BEA_CSF_Client_PostType {
 		$data_for_post = $data;
 		unset( $data_for_post['medias'], $data_for_post['terms'], $data_for_post['tags_input'], $data_for_post['post_category'] );
 
+		// Post data are expected to be escaped for wp_insert_post/wp_update_post
+		$data_for_post = wp_slash( $data_for_post );
+
 		// Merge post
 		if ( ! empty( $data['local_id'] ) && (int) $data['local_id'] > 0 ) {
 			$current_value = (int) get_post_meta( $data['local_id'], '_exclude_from_futur_sync', true );


### PR DESCRIPTION
Using `wp_insert_post`/`wp_update_post` without slashing data will result in some escape characters being strip from the post_content.

This can cause issues with ACF gutenberg blocks which store everything in the block json attribut :
* Invalid json  : **before** `"title": "Titre [test foo=\"bar\"]",` **after** `"title":"Titre [test foo="bar"]"`
* Missing line break  : **before** `"content": "• Ceci est du contenu\r\n• Et ceci aussi est du contenu\r\n\r\n",` **after** `"content":"• Ceci est du contenurn• Et ceci aussi est du contenurnrn",` 