### PR TITLE
Fix hook return that should be an array

### DIFF
--- a/classes/admin/admin-metaboxes.php
+++ b/classes/admin/admin-metaboxes.php
@@ -422,7 +422,7 @@ class BEA_CSF_Admin_Metaboxes {
 		);
 
 		if ( ! empty( $emitter_relation ) ) {
-			return false;
+			return $form_fields;
 		}
 
 		// Get syncs for current post_type and mode set to "auto"


### PR DESCRIPTION
Fix error on the filter that wait for an array as response but we return a bool.