### PR TITLE
Performance/object and script

### DIFF
--- a/classes/cli/queue.php
+++ b/classes/cli/queue.php
@@ -7,49 +7,24 @@ if ( ! defined( 'WP_CLI' ) ) {
 class BEA_CSF_Cli_Queue extends WP_CLI_Command {
 
 	/**
-	 * Exec cron by get all blogs with content, and proceed to sync !
+	 * Displays the queue status
 	 *
-	 * @param $args
-	 * @param $params
+	 * ## OPTIONS
 	 *
-	 * @throws \WP_CLI\ExitException
+	 * [--alternativeq=<alternativeq>]
+	 * : Use the alternative queue for the action.
+	 * ---
+	 * default: false
+	 * options:
+	 *   - true
+	 *   - false
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp content-sync-fusion queue status --alternativeq=false
+	 *
 	 */
-	public function process( $args, $params ) {
-		// Use maintenance queue ?
-		if ( isset( $params['alternativeq'] ) && 'true' === $params['alternativeq'] ) {
-			BEA_CSF_Async::switch_to_maintenance_queue();
-		} else {
-			$params['alternativeq'] = 'false';
-		}
-
-		// Get blogs ID with content to sync
-		$blog_ids = BEA_CSF_Async::get_blog_ids_from_queue();
-		if ( empty( $blog_ids ) ) {
-			WP_CLI::warning( __( 'No content to synchronize', 'bea-content-sync-fusion' ) );
-
-			return;
-		}
-
-		$total = count( $blog_ids );
-
-		$progress = \WP_CLI\Utils\make_progress_bar( 'Loop on site with content to synchronize', $total );
-		foreach ( $blog_ids as $blog_id ) {
-			WP_CLI::launch_self(
-				'content-sync-fusion queue pull',
-				array(),
-				array(
-					'alternativeq' => $params['alternativeq'],
-					'url'          => get_home_url( $blog_id, '/' ),
-				),
-				false,
-				false // Allow debug with this value to true
-			);
-
-			$progress->tick();
-		}
-		$progress->finish();
-	}
-
 	public function status( $args, $params ) {
 		// Use maintenance queue ?
 		if ( isset( $params['alternativeq'] ) && 'true' === $params['alternativeq'] ) {
@@ -71,6 +46,85 @@ class BEA_CSF_Cli_Queue extends WP_CLI_Command {
 		WP_CLI::success( sprintf( __( '%d items waiting on the queue', 'bea-content-sync-fusion' ), BEA_CSF_Async::get_counter() ) );
 	}
 
+	/**
+	 * Exec cron by get all blogs with content, and proceed to sync !
+	 *
+	 * @param $args
+	 * @param $params
+	 *
+	 * @throws \WP_CLI\ExitException
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--alternativeq=<alternativeq>]
+	 * : Use the alternative queue for the action
+	 * ---
+	 * default: false
+	 * options:
+	 *   - true
+	 *   - false
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp content-sync-fusion queue pull --alternativeq=false
+	 *
+	 */
+	public function process( $args, $params ) {
+		// Use maintenance queue ?
+		if ( isset( $params['alternativeq'] ) && 'true' === $params['alternativeq'] ) {
+			BEA_CSF_Async::switch_to_maintenance_queue();
+		} else {
+			$params['alternativeq'] = 'false';
+		}
+
+		// Get blogs ID with content to sync
+		$blog_ids = BEA_CSF_Async::get_blog_ids_from_queue();
+		if ( empty( $blog_ids ) ) {
+			WP_CLI::warning( __( 'No content to synchronize', 'bea-content-sync-fusion' ) );
+
+			return;
+		}
+
+		$total = count( $blog_ids );
+
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Loop on site with content to synchronize', $total );
+		foreach ( $blog_ids as $blog_id ) {
+			// Fill thearray with the current blog url
+			$params['url'] = get_home_url( $blog_id, '/' );
+
+			WP_CLI::launch_self(
+				'content-sync-fusion queue pull',
+				array(),
+				$params,
+				false,
+				false // Allow debug with this value to true
+			);
+
+			$progress->tick();
+		}
+		$progress->finish();
+	}
+
+	/**
+	 * Flushes the queue database.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--alternativeq=<alternativeq>]
+	 * : Use the alternative queue for the action
+	 * ---
+	 * default: false
+	 * options:
+	 *   - true
+	 *   - false
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp content-sync-fusion queue flush --alternativeq=false
+	 *
+	 */
 	public function flush( $args, $params ) {
 		// Use maintenance queue ?
 		if ( isset( $params['alternativeq'] ) && 'true' === $params['alternativeq'] ) {
@@ -81,6 +135,30 @@ class BEA_CSF_Cli_Queue extends WP_CLI_Command {
 		WP_CLI::success( __( 'Queue flushed with success !', 'bea-content-sync-fusion' ) );
 	}
 
+	/**
+	 * Pull content for all the sites into the network.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--alternativeq=<alternativeq>]
+	 * : Use the alternative queue for the action
+	 * ---
+	 * default: false
+	 * options:
+	 *   - true
+	 *   - false
+	 * ---
+	 *
+	 * [--quantity=<number>]
+	 * : Quantity of content to process
+	 * ---
+	 * default: 500
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp content-sync-fusion queue pull --alternativeq=false --quantity=20
+	 **/
 	public function pull( $args, $params ) {
 		// Use maintenance queue ?
 		if ( isset( $params['alternativeq'] ) && 'true' === $params['alternativeq'] ) {
@@ -115,8 +193,6 @@ class BEA_CSF_Cli_Queue extends WP_CLI_Command {
 		$progress->finish();
 
 		WP_CLI::success( __( 'End of content synchronization', 'bea-content-sync-fusion' ) );
-
-		WP_CLI::run_command( array( 'cache', 'flush' ) );
 	}
 
 	/**
@@ -124,6 +200,22 @@ class BEA_CSF_Cli_Queue extends WP_CLI_Command {
 	 *
 	 * @param $args
 	 * @param $params
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--alternativeq]
+	 * : Use the alternative queue for the action
+	 * ---
+	 * default: false
+	 * options:
+	 *   - true
+	 *   - false
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp content-sync-fusion queue get_sites --alternativeq=false --quantity=20
+
 	 */
 	public function get_sites( $args, $params ) {
 		// Use maintenance queue ?

--- a/classes/cli/resync.php
+++ b/classes/cli/resync.php
@@ -244,8 +244,6 @@ class BEA_CSF_Cli_Resync extends WP_CLI_Command {
 		$progress->finish();
 
 		WP_CLI::success( __( 'End of content resync', 'bea-content-sync-fusion' ) );
-
-		WP_CLI::run_command( array( 'cache', 'flush' ) );
 	}
 
 	/**

--- a/cron/cronjob.sh
+++ b/cron/cronjob.sh
@@ -5,11 +5,12 @@
 # We recommend to exec this task each minute : */1 * * * *
 
 ## USAGE
-# 3 arguments max
-# 1st argument : REQUIRED - the network URL of WordPress, eg : mydomain.fr, https://mydomain.fr
-# 2nd argument : OPTIONAL - the WP-CLI binary command, eg: wp, "lando wp", "php wp-cli.phar" (Default value : wp)
-# 3nd argument : OPTIONAL - the path of WP installation, eg: /var/www/wp/ (not default value)
+# 5 arguments max
+# 1st argument  : REQUIRED - the network URL of WordPress, eg : mydomain.fr, https://mydomain.fr
+# 2nd argument  : OPTIONAL - the WP-CLI binary command, eg: wp, "lando wp", "php wp-cli.phar" (Default value : wp)
+# 3nd argument  : OPTIONAL - the path of WP installation, eg: /var/www/wp/ (not default value)
 # 4rth argument : OPTIONAL - the alternate queue, eg : true (Default value : false)
+# 5th argument  : OPTIONAL - additional parameters to pass to WPCLI, eg : --skip-plugins=stream
 
 ## TODO
 # Allow to customize path for PID file
@@ -35,6 +36,7 @@ fi
 WP_NETWORK_URL=${1}
 WP_CLI_BIN=${2:-wp}
 ALT_QUEUE=${4:-false}
+ADDITIONAL_ARGS=${5:-''}
 
 # Wrap the 3rd argument if is filled
 if [ -n "${3:-}" ]; then
@@ -79,10 +81,10 @@ else
 fi
 
 # Regular queue
-$WP_CLI_BIN content-sync-fusion queue get_sites --url="$WP_NETWORK_URL" $WP_PATH  | xargs -I {} $WP_CLI_BIN content-sync-fusion queue pull --alternativeq=$ALT_QUEUE --url={}  $WP_PATH 
+$WP_CLI_BIN content-sync-fusion queue get_sites --url="$WP_NETWORK_URL" ADDITIONAL_ARGS $WP_PATH  | xargs -I {} $WP_CLI_BIN content-sync-fusion queue pull --alternativeq=$ALT_QUEUE --url={} ADDITIONAL_ARGS $WP_PATH
 
 # Check for resync content (new site/blog)
-$WP_CLI_BIN content-sync-fusion resync new_sites --smart=true --attachments=true --post_type=true --taxonomies=true --url="$WP_NETWORK_URL" $WP_PATH
+$WP_CLI_BIN content-sync-fusion resync new_sites --smart=true --attachments=true --post_type=true --taxonomies=true --url="$WP_NETWORK_URL" ADDITIONAL_ARGS $WP_PATH
 
 # Remove lock PIDFILE
 rm $PIDFILE

--- a/cron/cronjob.sh
+++ b/cron/cronjob.sh
@@ -81,10 +81,10 @@ else
 fi
 
 # Regular queue
-$WP_CLI_BIN content-sync-fusion queue get_sites --url="$WP_NETWORK_URL" ADDITIONAL_ARGS $WP_PATH  | xargs -I {} $WP_CLI_BIN content-sync-fusion queue pull --alternativeq=$ALT_QUEUE --url={} ADDITIONAL_ARGS $WP_PATH
+$WP_CLI_BIN content-sync-fusion queue get_sites --url="$WP_NETWORK_URL" $ADDITIONAL_ARGS $WP_PATH  | xargs -I {} $WP_CLI_BIN content-sync-fusion queue pull --alternativeq=$ALT_QUEUE --url={} $ADDITIONAL_ARGS $WP_PATH
 
 # Check for resync content (new site/blog)
-$WP_CLI_BIN content-sync-fusion resync new_sites --smart=true --attachments=true --post_type=true --taxonomies=true --url="$WP_NETWORK_URL" ADDITIONAL_ARGS $WP_PATH
+$WP_CLI_BIN content-sync-fusion resync new_sites --smart=true --attachments=true --post_type=true --taxonomies=true --url="$WP_NETWORK_URL" $ADDITIONAL_ARGS $WP_PATH
 
 # Remove lock PIDFILE
 rm $PIDFILE


### PR DESCRIPTION
Lorsque l'on fait un wp_cache_flush à la fin du processus de synchronisation, ça vide la totalité du cache objet sur un multisite.
Avec un gros multisite et beaucoup de contenu ce cache objet n'est quasiment jamais rempli en cas de modification.
Puisque nous avons implémenté une couche de cache intelligente, elle se videra d'elle même.
Si la personne souhaite modifier ce comportement, elle ajoutera d'elle-même le wp cache flush à la fin du processus.


Sur le script de synchronisation, j'ajoute la possibilité de passer ses propres arguments supplémentaires aux commandes, pour pouvoir ajouter des --skip-plugins etc. afin de passer stream etc.