### PR TITLE
Using alternative queue for the get_sites cronjob too

### DIFF
--- a/cron/cronjob.sh
+++ b/cron/cronjob.sh
@@ -81,7 +81,7 @@ else
 fi
 
 # Regular queue
-$WP_CLI_BIN content-sync-fusion queue get_sites --url="$WP_NETWORK_URL" $ADDITIONAL_ARGS $WP_PATH  | xargs -I {} $WP_CLI_BIN content-sync-fusion queue pull --alternativeq=$ALT_QUEUE --url={} $ADDITIONAL_ARGS $WP_PATH
+$WP_CLI_BIN content-sync-fusion queue get_sites --alternativeq=$ALT_QUEUE --url="$WP_NETWORK_URL" $ADDITIONAL_ARGS $WP_PATH  | xargs -I {} $WP_CLI_BIN content-sync-fusion queue pull --alternativeq=$ALT_QUEUE --url={} $ADDITIONAL_ARGS $WP_PATH
 
 # Check for resync content (new site/blog)
 $WP_CLI_BIN content-sync-fusion resync new_sites --smart=true --attachments=true --post_type=true --taxonomies=true --url="$WP_NETWORK_URL" $ADDITIONAL_ARGS $WP_PATH


### PR DESCRIPTION
fix: Use the alternativeq param to the cronjob too. Or it will always get the normal queue.